### PR TITLE
Use cache action for caching gems

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby:
+        ruby-version:
           - 2.4
           - 2.5
           - 2.6
@@ -22,7 +22,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby-version }}
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ matrix.ruby-version }}
+          restore-keys: ${{ runner.os }}-gems-
       - run: |
           gem install bundler
           bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,5 +30,6 @@ jobs:
           restore-keys: ${{ runner.os }}-gems-
       - run: |
           gem install bundler
+          bundle config path vendor/bundle
           bundle install
           bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ matrix.ruby-version }}
-          restore-keys: ${{ runner.os }}-gems-
+          key: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ruby-version }}-gems-
       - run: |
           gem install bundler
           bundle config path vendor/bundle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Denso::Calendar
 
+![Run RSpec](https://github.com/satoryu/denso-calendar/workflows/Run%20RSpec/badge.svg)
+
 This gem provides a CLI and API for developers to parse DENSO Calendar published in [the website](https://www.denso.com/jp/ja/about-us/calendar/).
 
 ## Installation


### PR DESCRIPTION
## References

- [依存関係をキャッシュしてワークフローのスピードを上げる - GitHub ヘルプ](https://help.github.com/ja/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows)
- [cache/examples.md at master · actions/cache](https://github.com/actions/cache/blob/master/examples.md#ruby---bundler)
